### PR TITLE
perl related change to disable the cpan command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,11 @@ RUN \
   chmod 0755 -R /hooks /init && \
   chmod 0777 /etc/passwd /etc/group && \
   mkdir --mode 0777 /usr/local/composer && \
-  COMPOSER_HOME=/usr/local/composer /usr/local/bin/composer global require drush/drush:8.*
+  COMPOSER_HOME=/usr/local/composer /usr/local/bin/composer global require drush/drush:8.* && \
+  mv /usr/bin/cpan /usr/bin/cpan_disabled && \
+  mv /usr/bin/cpan_override /usr/bin/cpan
 
 ENV COMPOSER_HOME=/var/www \
-    HOME=/var/www 
+    HOME=/var/www
 
 WORKDIR /var/www

--- a/files/usr/bin/cpan_override
+++ b/files/usr/bin/cpan_override
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "## The cpan command has been disabled ##
+
+To install cpan modules, list them in /var/www/cpan/modules.conf
+
+The modules will be installed automatically on the next reboot."


### PR DESCRIPTION
cpan will not work as expexted in the ssh context. This change disables the command and adds a substitute which displays info on using the modules.conf

rename cpan to cpan_disabled
add a new cpan command to display info on installing modules.